### PR TITLE
Bugfix: Fix syntax

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -12,7 +12,7 @@ inputs:
     required: true
   transform-configuration: 
     description: 'Transform app configurations based on build configuration'
-    required: true
+    required: false
     default: true
 runs:
   using: "composite"
@@ -40,7 +40,7 @@ runs:
         echo "ENVIRONMENT=Release" >> $GITHUB_ENV
       shell: bash
     - name: Transform Configuration
-      if: ${{ inputs.transform-configuration }} == true
+      if: ${{ inputs.transform-configuration == true }}
       run: |
           dotnet tool install --global dotnet-xdt
           dotnet xdt --source ./${{ inputs.project-path }}/App.config --transform ./${{ inputs.project-path }}/App.${{ env.ENVIRONMENT }}.config --output ./${{ inputs.project-path }}/App.config


### PR DESCRIPTION
`if: ${{ inputs.transform-configuration }} == true` is always true - this syntax is not correct for the intention. See Github Action's documentation for [an example of testing equality of a configuration value](https://docs.github.com/en/actions/learn-github-actions/expressions#example-for-workflow-step).

This PR also makes the `transform-configuration` setting optional, and defaults it to true for backwards compatibility.